### PR TITLE
Fix a couple more prefix search issues

### DIFF
--- a/art_node.go
+++ b/art_node.go
@@ -131,7 +131,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 
 	if n.prefixLen > MAX_PREFIX_LEN {
 		for ; index < MAX_PREFIX_LEN; index++ {
-			if index+depth >= len(key) || key[depth+index] != n.prefix[index] {
+			if depth+index >= len(key) || key[depth+index] != n.prefix[index] {
 				return index
 			}
 		}
@@ -139,7 +139,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 		minKey := n.Minimum().key
 
 		for ; index < n.prefixLen; index++ {
-			if key[depth+index] != minKey[depth+index] {
+			if depth+index >= len(key) || key[depth+index] != minKey[depth+index] {
 				return index
 			}
 		}
@@ -147,7 +147,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 	} else {
 
 		for ; index < n.prefixLen; index++ {
-			if index+depth >= len(key) || key[depth+index] != n.prefix[index] {
+			if depth+index >= len(key) || key[depth+index] != n.prefix[index] {
 				return index
 			}
 		}

--- a/art_node.go
+++ b/art_node.go
@@ -121,8 +121,11 @@ func (n *ArtNode) IsMatch(key []byte) bool {
 
 }
 
-// Returns the number of bytes that differ between the passed in key
-// and the compressed path of the current node at the specified depth.
+// Returns the relative index of the first byte that doesn't match
+// between key and the current node's prefix, starting at depth.
+// Ex: if the depth is 3 and the current prefix is 'baz',
+//     for key "foobar" the result is 2, for "foobaz", 3, and for
+//     "fooquux" 0.
 func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 	index := 0
 

--- a/art_node.go
+++ b/art_node.go
@@ -131,7 +131,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 
 	if n.prefixLen > MAX_PREFIX_LEN {
 		for ; index < MAX_PREFIX_LEN; index++ {
-			if key[depth+index] != n.prefix[index] {
+			if index+depth >= len(key) || key[depth+index] != n.prefix[index] {
 				return index
 			}
 		}
@@ -146,8 +146,8 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 
 	} else {
 
-		for ; index < n.prefixLen && depth+index < len(key); index++ {
-			if key[depth+index] != n.prefix[index] {
+		for ; index < n.prefixLen; index++ {
+			if index+depth >= len(key) || key[depth+index] != n.prefix[index] {
 				return index
 			}
 		}

--- a/art_node.go
+++ b/art_node.go
@@ -128,28 +128,14 @@ func (n *ArtNode) IsMatch(key []byte) bool {
 //     "fooquux" 0.
 func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 	index := 0
+	prefix := n.prefix
 
-	if n.prefixLen > MAX_PREFIX_LEN {
-		for ; index < MAX_PREFIX_LEN; index++ {
-			if depth+index >= len(key) || key[depth+index] != n.prefix[index] {
-				return index
-			}
-		}
-
-		minKey := n.Minimum().key
-
-		for ; index < n.prefixLen; index++ {
-			if depth+index >= len(key) || key[depth+index] != minKey[depth+index] {
-				return index
-			}
-		}
-
-	} else {
-
-		for ; index < n.prefixLen; index++ {
-			if depth+index >= len(key) || key[depth+index] != n.prefix[index] {
-				return index
-			}
+	for ; index < n.prefixLen && depth+index < len(key) && key[depth+index] == prefix[index]; index++ {
+		if index == MAX_PREFIX_LEN-1 {
+			// Once we get past MAX_PREFIX_LEN, the rest of the prefix isn't stored.
+			// So grab the first child of this node; the first n.prefixLen bytes of
+			// its key are the full prefix.
+			prefix = n.Minimum().key[depth:]
 		}
 	}
 

--- a/art_tree.go
+++ b/art_tree.go
@@ -81,15 +81,18 @@ func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode
 
 		// Check if our key mismatches the current compressed path
 		prefixMismatch := current.PrefixMismatch(key, depth)
-		if prefixMismatch == 0 && prefixMismatch < current.prefixLen {
-			// Bail if there's a mismatch during traversal.
-			return nil
-		} else {
-			// Otherwise, increase depth accordingly.
+		if prefixMismatch == current.prefixLen {
+			// whole prefix matches
 			depth += current.prefixLen
 			if depth > maxKeyIndex {
 				return current
 			}
+		} else if prefixMismatch == len(key)-depth {
+			// consumed whole key
+			return current
+		} else {
+			// mismatch
+			return nil
 		}
 
 		// Find the next node at the specified index, and update depth.

--- a/art_tree.go
+++ b/art_tree.go
@@ -58,7 +58,7 @@ func (t *ArtTree) PrefixSearchChan(key []byte) chan Result {
 func (t *ArtTree) Search(key []byte) interface{} {
 	key = ensureNullTerminatedKey(key)
 	foundNode := t.searchHelper(t.root, key, 0)
-	if foundNode != nil {
+	if foundNode != nil && foundNode.IsMatch(key) {
 		return foundNode.value
 	}
 	return nil
@@ -70,16 +70,12 @@ func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode
 	// While we have nodes to search
 	if current != nil {
 		maxKeyIndex := len(key) - 1
+		if depth > maxKeyIndex {
+			return current
+		}
 
-		// Check if the current is a match
-		if current.IsLeaf() {
-			if current.IsMatch(key) {
-				return current
-			}
-
-			// Bail if no match
-			return nil
-		} else if depth > maxKeyIndex {
+		// Check if the current is a match (including prefix match)
+		if current.IsLeaf() && len(current.key) >= len(key) && bytes.Equal(key, current.key[0:len(key)]) {
 			return current
 		}
 

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -890,3 +890,32 @@ func TestPrefixSearch4(t *testing.T) {
 
 	}
 }
+
+func TestPrefixSearch5(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"foot", "food",
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	rr := tree.PrefixSearch([]byte("for"))
+	if len(rr) > 0 {
+		t.Error("should get no results for for")
+	}
+
+	rr = tree.PrefixSearch([]byte("fo"))
+	if rr == nil {
+		t.Error("something should have been found for fo")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "food,foot," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+}

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -919,3 +919,32 @@ func TestPrefixSearch5(t *testing.T) {
 		}
 	}
 }
+
+func TestPrefixSearchWithLongCommonPrefix(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"full-name:abc", "full-name:abc1",
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	rr := tree.PrefixSearch([]byte("full-name:ax"))
+	if len(rr) > 0 {
+		t.Error("should get no results for for")
+	}
+
+	rr = tree.PrefixSearch([]byte("full-name:a"))
+	if rr == nil {
+		t.Error("something should have been found for fo")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "full-name:abc,full-name:abc1," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+}

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -861,3 +861,32 @@ func TestPrefixSearch3(t *testing.T) {
 		}
 	}
 }
+
+func TestPrefixSearch4(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"a",
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	rr := tree.PrefixSearch([]byte(""))
+	if rr == nil {
+		t.Error("something should have been found for ''")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "a," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+	rr = tree.PrefixSearch([]byte("x"))
+	if rr == nil || len(rr) > 1 {
+		t.Error("Shouldn't have gotten results for x")
+
+	}
+}


### PR DESCRIPTION
1) Wasn't correctly handling a search that ended at a leaf node but didn't consume the key (eg, insert "a", search for "").
2) Wasn't correctly handling a partial prefix mismatch at an internal node (eg, if the current node had prefix "foo" and remaining key was "for", the partial match would be good enough and we'd call it a hit).

Now passes all the tests I've thrown at it.
